### PR TITLE
Add secure connection option for S3

### DIFF
--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	logger.Info("Database connected.")
 
-	s3Client, err := minio.New(config.S3.Endpoint, config.S3.AccessKey, config.S3.SecretKey, true)
+	s3Client, err := minio.New(config.S3.Endpoint, config.S3.AccessKey, config.S3.SecretKey, config.S3.Secure)
 	if err != nil {
 		logger.Fatal("Failed to connect to S3", zap.Error(err))
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 			Bucket string `env:"BUCKET,required"`
 		} `envPrefix:"ARCHIVE_"`
 
+		Secure    bool   `env:"SECURE" envDefault:"true"`
 		Endpoint  string `env:"ENDPOINT,required"`
 		AccessKey string `env:"ACCESS_KEY,required"`
 		SecretKey string `env:"SECRET_KEY,required"`


### PR DESCRIPTION
This PR adds a feature for users who do not want to deal with TLS with S3. *This is mostly a feature for self-hosted instances of the bot.*

This pull request includes changes to enhance the configuration and initialization of the S3 client by adding a new configuration option for secure connections.

Configuration enhancement:

* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR44): Added a new `Secure` boolean field to the `Config` struct to allow configuration of secure connections to the S3 service. This field is set to `true` by default.

Initialization update:

* [`cmd/import/main.go`](diffhunk://#diff-0830c03a3e206ac5ba38b34ed6804d3fc533f00a5d06ac9a00ebfcd60a0ff096L51-R51): Updated the initialization of the S3 client to use the new `Secure` configuration option instead of a hardcoded `true` value.

## More Pull Requests
- https://github.com/TicketsBot-cloud/logarchiver/pull/1
- https://github.com/TicketsBot-cloud/dashboard/pull/10