### PR TITLE
Add secure connection option for S3

### DIFF
--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	logger.Info("Database connected.")
 
-	s3ImportClient, err := minio.New(config.S3.Import.Endpoint, config.S3.Import.AccessKey, config.S3.Import.SecretKey, true)
+	s3ImportClient, err := minio.New(config.S3.Import.Endpoint, config.S3.Import.AccessKey, config.S3.Import.SecretKey, config.S3.Import.Secure)
 	if err != nil {
 		logger.Fatal("Failed to connect to Import S3", zap.Error(err))
 		return
@@ -57,7 +57,7 @@ func main() {
 	logger.Info("Import S3 connected.")
 	utils.S3ImportClient = s3ImportClient
 
-	s3ArchiveClient, err := minio.New(config.S3.Archive.Endpoint, config.S3.Archive.AccessKey, config.S3.Archive.SecretKey, true)
+	s3ArchiveClient, err := minio.New(config.S3.Archive.Endpoint, config.S3.Archive.AccessKey, config.S3.Archive.SecretKey, config.S3.Archive.Secure)
 	if err != nil {
 		logger.Fatal("Failed to connect to Archive S3", zap.Error(err))
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	S3 struct {
 		Import struct {
 			Endpoint  string `env:"ENDPOINT,required"`
+			Secure    bool   `env:"SECURE" envDefault:"true"`
 			AccessKey string `env:"ACCESS_KEY,required"`
 			SecretKey string `env:"SECRET_KEY,required"`
 			Bucket    string `env:"BUCKET,required"`
@@ -42,6 +43,7 @@ type Config struct {
 
 		Archive struct {
 			Endpoint  string `env:"ENDPOINT,required"`
+			Secure    bool   `env:"SECURE" envDefault:"true"`
 			AccessKey string `env:"ACCESS_KEY,required"`
 			SecretKey string `env:"SECRET_KEY,required"`
 			Bucket    string `env:"BUCKET,required"`


### PR DESCRIPTION
This PR adds a feature for users who do not want to deal with TLS with S3. *This is mostly a feature for self-hosted instances of the bot.*

This pull request introduces a configuration enhancement to make the S3 connection security settings configurable via environment variables. The most important changes include adding a `Secure` field to the S3 configuration structs and updating the S3 client initialization logic to use this new field.

### Configuration Enhancements:
* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR38-R46): Added a `Secure` field (type `bool`) to both the `Import` and `Archive` S3 configuration structs. This field is mapped to the `SECURE` environment variable with a default value of `true`.

### S3 Client Initialization Updates:
* [`cmd/import/main.go`](diffhunk://#diff-0830c03a3e206ac5ba38b34ed6804d3fc533f00a5d06ac9a00ebfcd60a0ff096L51-R51): Updated the `s3ImportClient` initialization to use the `config.S3.Import.Secure` field instead of a hardcoded `true` value.
* [`cmd/import/main.go`](diffhunk://#diff-0830c03a3e206ac5ba38b34ed6804d3fc533f00a5d06ac9a00ebfcd60a0ff096L60-R60): Updated the `s3ArchiveClient` initialization to use the `config.S3.Archive.Secure` field instead of a hardcoded `true` value.

## More Pull Requests
- https://github.com/TicketsBot-cloud/logarchiver/pull/2
- https://github.com/TicketsBot-cloud/dashboard/pull/10